### PR TITLE
Make no-trailing-spaces work on Windows

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017 Daijiro Wachi
+Copyright (c) 2016 Jonathan Verrecchia
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.js
+++ b/index.js
@@ -2,6 +2,23 @@
 
 "use strict";
 
+const rule = require("unified-lint-rule");
+const noTrailingSpaces = rule("remark-lint:no-trailing-spaces", (ast, file) => {
+  var lines = file.toString().split(/\r?\n/);
+  for (var i = 0; i < lines.length; i++) {
+    var currentLine = lines[i];
+    var lineIndex = i + 1;
+    if (/\s$/.test(currentLine)) {
+      file.message("Remove trailing whitespace", {
+        position: {
+          start: { line: lineIndex, column: currentLine.length + 1 },
+          end: { line: lineIndex }
+        }
+      });
+    }
+  }
+});
+
 module.exports.plugins = [
   require("remark-lint"),
   require("remark-lint-checkbox-content-indent"),
@@ -27,7 +44,7 @@ module.exports.plugins = [
   require("remark-lint-no-shortcut-reference-image"),
   require("remark-lint-no-table-indentation"),
   require("remark-lint-no-tabs"),
-  require("remark-lint-no-trailing-spaces"),
+  noTrailingSpaces,
   require("remark-lint-no-unused-definitions"),
   require("remark-lint-rule-style"),
   require("remark-lint-table-pipes"),


### PR DESCRIPTION
Right now linting documentation on Windows fails, with `Remove trailing whitespace  no-trailing-spaces  remark-lint` reported for each line. This is because `/\s$/` regex used in `remark-lint-no-trailing-spaces`  matches last `\r` on the line.

This PR fixes this by splitting the lines by `/\r?\n/`, not by `'\n'` as in original code. Since [it looks like the original repo has stalled for a bit](https://github.com/verekia/remark-lint-no-trailing-spaces/issues/3) this bundles the code here with the needed changes.

