### PR TITLE
Normalize on `RFC <number>`

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,8 @@ module.exports.plugins = [
       { no: "Github", yes: "GitHub" },
       { no: "Javascript", yes: "JavaScript" },
       { no: "Node.JS", yes: "Node.js" },
+      { no: "Rfc", yes: "RFC" },
+      { no: "rfc", yes: "RFC" },
       { no: "v8", yes: "V8" }
     ]
   ],

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ module.exports.plugins = [
       { no: "Javascript", yes: "JavaScript" },
       { no: "Node.JS", yes: "Node.js" },
       { no: "Rfc", yes: "RFC" },
+      { no: "[Rr][Ff][Cc]\\d+", yes: "RFC <number>" },
       { no: "rfc", yes: "RFC" },
       { no: "v8", yes: "V8" }
     ]


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/26695#issuecomment-473512021

The first commit prohibits `rfc` and `Rfc` to enforce uppercase `RFC`.

As of https://github.com/nodejs/node/commit/3b6344ce42f35e83a580ef55a19c23becccdaa07 this gives:
```console
doc/api/dns.md
    115:65-115:72  warning  Use "RFC" instead of "rfc"  prohibited-strings  remark-lint
    558:34-558:41  warning  Use "RFC" instead of "rfc"  prohibited-strings  remark-lint
    561:52-561:59  warning  Use "RFC" instead of "rfc"  prohibited-strings  remark-lint
    650:65-650:72  warning  Use "RFC" instead of "rfc"  prohibited-strings  remark-lint
  1011:34-1011:41  warning  Use "RFC" instead of "rfc"  prohibited-strings  remark-lint
  1014:52-1014:59  warning  Use "RFC" instead of "rfc"  prohibited-strings  remark-lint

⚠ 6 warnings
```

The second commit enforces a space between `RFC` and the number. This is possibly an abuse of prohibited-strings, but it does catch the cases where the space is omitted (the user message isn't that clear, especially if you are unfamiliar with regular expressions). As of https://github.com/nodejs/node/commit/3b6344ce42f35e83a580ef55a19c23becccdaa07:

```console
doc/api/buffer.md
    181:17-181:35  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint
    184:31-184:38  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint

doc/api/dns.md
    115:65-115:72  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint
    558:34-558:41  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint
    561:52-561:59  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint
    650:65-650:72  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint
  1011:34-1011:41  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint
  1014:52-1014:59  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint

doc/api/http.md
  2091:23-2092:15  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint

doc/api/http2.md
   3226:1-3227:17  warning  Use "RFC <number>" instead of "[Rr][Ff][Cc]\d+"  prohibited-strings  remark-lint

⚠ 10 warnings
```