### PR TITLE
feat: add remark-lint-no-consecutive-blank-lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports.plugins = [
   require("remark-lint-maximum-line-length"),
   require("remark-lint-no-auto-link-without-protocol"),
   require("remark-lint-no-blockquote-without-marker"),
+  require("remark-lint-no-consecutive-blank-lines"),
   require("remark-lint-no-duplicate-definitions"),
   require("remark-lint-no-file-name-articles"),
   require("remark-lint-no-file-name-consecutive-dashes"),

--- a/index.js
+++ b/index.js
@@ -2,15 +2,29 @@
 
 "use strict";
 
+// Add in rules alphabetically
 module.exports.plugins = [
   require("remark-lint"),
+  [require("remark-lint-blockquote-indentation"), 2],
+  [
+    require("remark-lint-checkbox-character-style"),
+    {
+      checked: "x",
+      unchecked: " "
+    }
+  ],
   require("remark-lint-checkbox-content-indent"),
+  [require("remark-lint-code-block-style"), "fenced"],
   require("remark-lint-definition-spacing"),
   require("remark-lint-fenced-code-flag"),
+  [require("remark-lint-fenced-code-marker"), "`"],
+  [require("remark-lint-file-extension"), "md"],
+  [require("remark-lint-first-heading-level"), 1],
   require("remark-lint-final-definition"),
   require("remark-lint-final-newline"),
   require("remark-lint-hard-break-spaces"),
   require("remark-lint-hard-break-spaces"),
+  [require("remark-lint-heading-style"), "atx"],
   [require("remark-lint-list-item-indent"), "space"],
   require("remark-lint-maximum-line-length"),
   require("remark-lint-no-auto-link-without-protocol"),
@@ -30,21 +44,6 @@ module.exports.plugins = [
   require("remark-lint-no-tabs"),
   require("remark-lint-no-trailing-spaces"),
   require("remark-lint-no-unused-definitions"),
-  require("remark-lint-rule-style"),
-  require("remark-lint-table-pipes"),
-  [require("remark-lint-blockquote-indentation"), 2],
-  [
-    require("remark-lint-checkbox-character-style"),
-    {
-      checked: "x",
-      unchecked: " "
-    }
-  ],
-  [require("remark-lint-code-block-style"), "fenced"],
-  [require("remark-lint-fenced-code-marker"), "`"],
-  [require("remark-lint-file-extension"), "md"],
-  [require("remark-lint-first-heading-level"), 1],
-  [require("remark-lint-heading-style"), "atx"],
   [
     require("remark-lint-prohibited-strings"),
     [
@@ -63,6 +62,8 @@ module.exports.plugins = [
       { no: "v8", yes: "V8" }
     ]
   ],
+  require("remark-lint-rule-style"),
   [require("remark-lint-strong-marker"), "*"],
-  [require("remark-lint-table-cell-padding"), "padded"]
+  [require("remark-lint-table-cell-padding"), "padded"],
+  require("remark-lint-table-pipes")
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,6 +238,18 @@
         "vfile-location": "^2.0.1"
       }
     },
+    "remark-lint-no-consecutive-blank-lines": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-consecutive-blank-lines/-/remark-lint-no-consecutive-blank-lines-1.0.3.tgz",
+      "integrity": "sha512-2Ef7fPxrfLditA7sTo2Qfqd+xwh/luWl8GzILE5vcWIxLDqKk3dTLJkB5nP+7Cr4kqWJAwXnRkEDd77ehrRV3A==",
+      "requires": {
+        "plur": "^3.0.0",
+        "unified-lint-rule": "^1.0.0",
+        "unist-util-generated": "^1.1.0",
+        "unist-util-position": "^3.0.0",
+        "unist-util-visit": "^1.1.1"
+      }
+    },
     "remark-lint-no-duplicate-definitions": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remark-lint-no-duplicate-definitions/-/remark-lint-no-duplicate-definitions-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "remark-lint-maximum-line-length": "^1.1.0",
     "remark-lint-no-auto-link-without-protocol": "^1.0.0",
     "remark-lint-no-blockquote-without-marker": "^2.0.2",
+    "remark-lint-no-consecutive-blank-lines": "^1.0.3",
     "remark-lint-no-duplicate-definitions": "^1.0.0",
     "remark-lint-no-file-name-articles": "^1.0.0",
     "remark-lint-no-file-name-consecutive-dashes": "^1.0.0",


### PR DESCRIPTION
This should be OK with https://github.com/nodejs/node/pull/29352, but I'm not sure if there are other affected repos that might also need to be checked/fixed before this can land