### PR TITLE
Travis CI: specify `depth 1` when cloning the Node.js repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: node_js
 
 node_js: node
 
-before_script: git clone https://github.com/nodejs/node.git tmp
+before_script: git clone https://github.com/nodejs/node.git tmp --depth 1
 
 script: npm run travis


### PR DESCRIPTION
This should speed things up.