### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Tests
 on: [push, pull_request]
 env:
   CI: true
+  NODE: 12.x
 
 jobs:
   test:
@@ -12,12 +13,15 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Clone nodejs/node repository
-        run: git clone https://github.com/nodejs/node.git tmp --depth 1
+        uses: actions/checkout@v2
+        with:
+          repository: nodejs/node
+          path: tmp
 
       - name: Set up Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: "12"
+          node-version: "${{ env.NODE }}"
 
       - run: node --version
       - run: npm --version


### PR DESCRIPTION
* use actions/checkout to clone the node repo
* add an env variable for the Node.js version we use

This shouldn't make any difference since actions/checkout has depth 1 by default. It's just that we will use actions across the whole thing.