### PR TITLE
chore: udpate prohibited strings to 1.5.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ module.exports.plugins = [
     require("remark-lint-checkbox-character-style"),
     {
       checked: "x",
-      unchecked: " "
-    }
+      unchecked: " ",
+    },
   ],
   require("remark-lint-checkbox-content-indent"),
   [require("remark-lint-code-block-style"), "fenced"],
@@ -39,27 +39,23 @@ module.exports.plugins = [
   [
     require("remark-lint-prohibited-strings"),
     [
-      { no: "End-Of-Life", yes: "End-of-Life" },
-      { no: "End-of-life", yes: "End-of-Life" },
-      { no: "Github", yes: "GitHub" },
+      { yes: "End-of-Life" },
+      { yes: "GitHub" },
       { no: "hostname", yes: "host name" },
-      { no: "[Jj]avascript", yes: "JavaScript" },
+      { yes: "JavaScript" },
       { no: "Node", yes: "Node.js" },
-      { no: "Node\\.JS", yes: "Node.js" },
-      { no: "node\\.js", yes: "Node.js" },
+      { yes: "Node.js" },
       { no: "Node\\.js's?", yes: "the Node.js" },
       { no: "[Nn]ote that", yes: "<nothing>" },
-      { no: "Rfc", yes: "RFC" },
+      { yes: "RFC" },
       { no: "[Rr][Ff][Cc]\\d+", yes: "RFC <number>" },
-      { no: "rfc", yes: "RFC" },
-      { no: "UNIX", yes: "Unix" },
-      { no: "unix", yes: "Unix" },
-      { no: "v8", yes: "V8" }
-    ]
+      { yes: "Unix" },
+      { yes: "V8" },
+    ],
   ],
   require("remark-lint-rule-style"),
   [require("remark-lint-strong-marker"), "*"],
   [require("remark-lint-table-cell-padding"), "padded"],
   require("remark-lint-table-pipes"),
-  [require("remark-lint-unordered-list-marker-style"), "*"]
+  [require("remark-lint-unordered-list-marker-style"), "*"],
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1339,12 +1339,22 @@
       }
     },
     "remark-lint-prohibited-strings": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-prohibited-strings/-/remark-lint-prohibited-strings-1.2.1.tgz",
-      "integrity": "sha512-i3LatoJn/eHkgawdi3eoynikQa5zIEDX+GYcvu4ns5LsOvIrT8WcuvgYQ2kbEFbV0KTy7yBAGLJ9040xs1ssXA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/remark-lint-prohibited-strings/-/remark-lint-prohibited-strings-1.5.1.tgz",
+      "integrity": "sha512-YZoRWbzIGRIQkngAowwAKG39kUAGSalYvrxqTzUU4LYj1dS37q7i5WDr4m/mnCcc5KwRin08D62Dphs6g9Btnw==",
       "requires": {
+        "escape-string-regexp": "^4.0.0",
         "unified-lint-rule": "^1.0.2",
-        "unist-util-visit": "^2.0.0"
+        "unist-util-position": "^3.1.0",
+        "unist-util-visit": "^2.0.0",
+        "vfile-location": "^3.0.1"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
       }
     },
     "remark-lint-rule-style": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "remark-lint-no-table-indentation": "^2.0.0",
     "remark-lint-no-tabs": "^2.0.0",
     "remark-lint-no-trailing-spaces": "^2.0.1",
-    "remark-lint-prohibited-strings": "^1.2.1",
+    "remark-lint-prohibited-strings": "^1.5.1",
     "remark-lint-rule-style": "^2.0.0",
     "remark-lint-strong-marker": "^2.0.0",
     "remark-lint-table-cell-padding": "^2.0.0",


### PR DESCRIPTION
Update remark-lint-prohibited-strings@1.5.1 and simplify configuration.