### PR TITLE
feat: Add NodeJS to prohibited strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports.plugins = [
       { yes: "JavaScript" },
       { no: "Node", yes: "Node.js" },
       { yes: "Node.js" },
+      { no: "Node[Jj][Ss]", yes: "Node.js" },
       { no: "Node\\.js's?", yes: "the Node.js" },
       { no: "[Nn]ote that", yes: "<nothing>" },
       { yes: "RFC" },


### PR DESCRIPTION
I think this used to be in here, so maybe it was dropped for a reason. I think I've mostly seen this in the website content rather than the core