### PR TITLE
feat: prohibit missing info string

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports.plugins = [
   require("remark-lint-checkbox-content-indent"),
   [require("remark-lint-code-block-style"), "fenced"],
   require("remark-lint-definition-spacing"),
-  require("remark-lint-fenced-code-flag"),
+  [require("remark-lint-fenced-code-flag"), { allowEmpty: false }],
   [require("remark-lint-fenced-code-marker"), "`"],
   [require("remark-lint-file-extension"), "md"],
   require("remark-lint-final-definition"),


### PR DESCRIPTION
It seems as though we can begin making progress in the area of linting Markdown code fences by at least [disallowing blank info strings](https://github.com/remarkjs/remark-lint/tree/master/packages/remark-lint-fenced-code-flag#not-okmd-1). The reasoning is sound, imo.

/see https://github.com/nodejs/node/issues/32938#issuecomment-619526613
/cc @aduh95 @Trott