### PR TITLE
chore: Don't build dependabot branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
 name: Tests
-on: [push, pull_request]
+
+on:
+  push:
+    branches-ignore:
+    - "dependabot/**"
+  pull_request:
+
 env:
   CI: true
   NODE: 12.x


### PR DESCRIPTION

Still build on the dependabot PRs