### PR TITLE
fix: bump remark-lint-prohibited-strings from 1.5.1 to 1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1339,9 +1339,9 @@
       }
     },
     "remark-lint-prohibited-strings": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/remark-lint-prohibited-strings/-/remark-lint-prohibited-strings-1.5.1.tgz",
-      "integrity": "sha512-YZoRWbzIGRIQkngAowwAKG39kUAGSalYvrxqTzUU4LYj1dS37q7i5WDr4m/mnCcc5KwRin08D62Dphs6g9Btnw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/remark-lint-prohibited-strings/-/remark-lint-prohibited-strings-1.5.2.tgz",
+      "integrity": "sha512-1+WIHboeLxmAnlxTFW6XNfvxvhnC2WRxn0rGgcNp/M7CrANHhnadY2/YeXFLF9oY22SAylrxiPG9eAuUmJuW6w==",
       "requires": {
         "escape-string-regexp": "^4.0.0",
         "unified-lint-rule": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "remark-lint-no-table-indentation": "^2.0.0",
     "remark-lint-no-tabs": "^2.0.0",
     "remark-lint-no-trailing-spaces": "^2.0.1",
-    "remark-lint-prohibited-strings": "^1.5.1",
+    "remark-lint-prohibited-strings": "^1.5.2",
     "remark-lint-rule-style": "^2.0.0",
     "remark-lint-strong-marker": "^2.0.0",
     "remark-lint-table-cell-padding": "^2.0.0",


### PR DESCRIPTION
This fixes a bug that causes remark-preset-lint-node to miss some
errors.

Refs: https://github.com/nodejs/node/pull/33691