### PR TITLE
chore: update CI linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lockfile-lint": "lockfile-lint --allowed-hosts npm --allowed-schemes https: --empty-hostname false --type npm --path package-lock.json",
-    "remark": "remark \"tmp/*.md\" \"tmp/doc/**/*.md\" \"tmp/lib/**/*.md\" \"tmp/benchmark/**/*.md\" \"tmp/test/[a-eg-z]*/**/*.md\" \"tmp/tools/doc/*.md\" \"tmp/tools/icu/**/*.md\" --use . --use gfm -fq",
+    "remark": "remark \"tmp/*.md\" \"tmp/doc/**/*.md\" \"tmp/lib/**/*.md\" \"tmp/benchmark/**/*.md\" \"tmp/src/**/*.md\" \"tmp/test/README.md\" \"tmp/test/[a-eg-z]*/**/*.md\" \"tmp/tools/doc/*.md\" \"tmp/tools/icu/**/*.md\" --use . --use gfm -fq",
     "test": "prettier index.js --write",
     "test-ci": "npm run lockfile-lint && npm run remark"
   },


### PR DESCRIPTION
The current CI missed a pair of README files (one in test and one in
src) in Node.js core.

I expect this to fail until https://github.com/nodejs/node/pull/35905 lands (as it contains a commit that fixes lint errors in the two missed files).