### PR TITLE
feat: allowlist for version numbers in YAML comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,34 @@ npm test
 
 ### Adding the language to the documentation style guide
 
-1. PR the [nodejs/node](https://github.com/nodejs/node) repo adding the language/grammar to the [documentation style guide](https://github.com/nodejs/node/blob/master/doc/guides/doc-style-guide.md)
+1. PR the [nodejs/node](https://github.com/nodejs/node) repo adding the
+   language/grammar to the
+   [documentation style guide](https://github.com/nodejs/node/blob/master/doc/guides/doc-style-guide.md).
 
 ### Adding the language to the linter
 
-1. PR this repo adding the language/grammar
-1. Bump this package version, publish it
-1. In [node-lint-md-cli-rollup](https://github.com/nodejs/node/tree/master/tools/node-lint-md-cli-rollup), bump the `remark-preset-lint-node` dependency 
-1. In the `nodejs/node` repo, rebuild the Markdown linter (`make lint-md-rollup`)
-1. PR the `nodejs/node` repo with the updated linter
+1. PR this repo adding the language/grammar.
+1. Bump this package version, publish it.
+1. In
+   [node-lint-md-cli-rollup](https://github.com/nodejs/node/tree/master/tools/node-lint-md-cli-rollup),
+   bump the `remark-preset-lint-node` dependency.
+1. In the `nodejs/node` repo, rebuild the Markdown linter
+   (`make lint-md-rollup`).
+1. PR the `nodejs/node` repo with the updated linter.
+
+## Environment variables
+
+#### `NODE_RELEASED_VERSIONS`
+
+On runtime, the linter will check the environment if the
+`NODE_RELEASED_VERSIONS` variable is defined; if it's there, it will use the
+content of the variable as a comma-separated list of allowed version numbers.
+This list is supposed to be built from the changelog(s), and validates the
+version numbers for the `nodejs-yaml-comments` rule.
+
+For better compatibility with the nodejs/node changelogs, there are a few
+exceptions:
+
+- Version numbers `^0.0.0 || ^0.1.0` are not validated using the provided list,
+  they are validating using the `vx.x.x` pattern.
+- `REPLACEME` placeholder is always valid, regardless it's in the list or not.

--- a/remark-lint-nodejs-yaml-comments.js
+++ b/remark-lint-nodejs-yaml-comments.js
@@ -22,11 +22,11 @@ const validVersionNumberRegex = /^v\d+\.\d+\.\d+$/;
 const prUrlRegex = new RegExp("^https://github.com/nodejs/node/pull/\\d+$");
 const privatePRUrl = "https://github.com/nodejs-private/node-private/pull/";
 
-let releasedVersion;
+let releasedVersions;
 let invalidVersionMessage = "version(s) must respect the pattern `vx.x.x` or";
 if (process.env.NODE_RELEASED_VERSIONS) {
   console.log("Using release list from env...");
-  releasedVersion = process.env.NODE_RELEASED_VERSIONS.split(",").map(
+  releasedVersions = process.env.NODE_RELEASED_VERSIONS.split(",").map(
     (v) => `v${v}`
   );
   invalidVersionMessage = `version not listed in the changelogs, `;
@@ -55,11 +55,11 @@ function containsInvalidVersionNumber(version) {
   if (version === undefined || version === VERSION_PLACEHOLDER) return false;
 
   if (
-    releasedVersion &&
+    releasedVersions &&
     // Always ignore 0.0.x and 0.1.x release numbers:
     (version[1] !== "0" || (version[3] !== "0" && version[3] !== "1"))
   )
-    return !releasedVersion.includes(version);
+    return !releasedVersions.includes(version);
 
   return !validVersionNumberRegex.test(version);
 }

--- a/remark-lint-nodejs-yaml-comments.js
+++ b/remark-lint-nodejs-yaml-comments.js
@@ -29,7 +29,6 @@ if (process.env.NODE_RELEASED_VERSIONS) {
   releasedVersion = process.env.NODE_RELEASED_VERSIONS.split(",").map(
     (v) => `v${v}`
   );
-  releasedVersion.push(undefined, VERSION_PLACEHOLDER);
   invalidVersionMessage = `version not listed in the changelogs, `;
 }
 invalidVersionMessage += `use the placeholder \`${VERSION_PLACEHOLDER}\``;
@@ -53,16 +52,16 @@ function containsInvalidVersionNumber(version) {
     return version.some(containsInvalidVersionNumber);
   }
 
-  if (version?.[1] === "0" && (version[3] === "0" || version[3] === "1")) {
-    return !validVersionNumberRegex.test(version);
-  }
+  if (version === undefined || version === VERSION_PLACEHOLDER) return false;
 
-  return (
-    !releasedVersion?.includes(version) ??
-    (version !== undefined &&
-      version !== VERSION_PLACEHOLDER &&
-      !validVersionNumberRegex.test(version))
-  );
+  if (
+    releasedVersion &&
+    // Always ignore 0.0.x and 0.1.x release numbers:
+    (version[1] !== "0" || (version[3] !== "0" && version[3] !== "1"))
+  )
+    return !releasedVersion.includes(version);
+
+  return !validVersionNumberRegex.test(version);
 }
 const getValidSemver = (version) =>
   version === VERSION_PLACEHOLDER ? MAX_SAFE_SEMVER_VERSION : version;


### PR DESCRIPTION
If an environment variable `NODE_RELEASED_VERSIONS` is detected, it is
used to validate the version numbers in the YAML comments. At the
notable exception of version numbers 0.0.x and 0.1.x,  and the
`REPLACEME` placeholder, any value not in the list is reported as
invalid.

The idea is to add a script on the node repo GH actions to parse the changelogs to populate the env variable. It won't change anything for doing local linting, but may help spot version errors when reviewing PRs.
For info, it let me spot https://github.com/nodejs/node/pull/37231 and https://github.com/nodejs/node/pull/37232, and I've seen a few times contributors trying to guess the next release version number because they didn't know about `REPLACEME`.