### PR TITLE
chore: allow cjs and mjs info strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ module.exports.plugins = [
       flags: [
         "bash",
         "c",
+        "cjs",
         "coffee",
         "console",
         "cpp",
@@ -32,6 +33,7 @@ module.exports.plugins = [
         "js",
         "json",
         "markdown",
+        "mjs",
         "powershell",
         "r",
         "text",


### PR DESCRIPTION
It seems ESLint folks are not interested in my meta string proposal, I guess the right move would be to move from

````markdown
```js esm
// ES module
export {};
```

```js cjs
// CJS module
module.exports = {};
```

```js
// Whichever
console.log();
```
````

to

````markdown
```mjs
// ES module
export {};
```

```cjs
// CJS module
module.exports = {};
```

```js
// Whichever
console.log();
```
````

Refs: https://github.com/nodejs/node/pull/37162
Refs: https://github.com/nodejs/node/pull/37311
Refs: https://github.com/eslint/eslint-plugin-markdown/issues/170

---

FWIW, I'd be up to fork the eslint markdown plugin and maintain ourselves support for the meta string instead, but maybe it's not worth the maintenance burden.