### PR TITLE
chore: fix gitignore entry for tmp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ jspm_packages
 .node_repl_history
 
 # Cloned nodejs/node for testing
-tmp/
+tmp


### PR DESCRIPTION
tmp is a symlink and not a directory so `tmp/` doesn't work to ignore
it.