### PR TITLE
fix: Local file path check error when starting with "file://..."

### DIFF
--- a/remark-lint-nodejs-links.js
+++ b/remark-lint-nodejs-links.js
@@ -21,7 +21,7 @@ function validateLinks(tree, vfile) {
   for (const node of getLinksRecursively(tree)) {
     if (node.url[0] !== "#") {
       const targetURL = new URL(node.url, currentFileURL);
-      if (targetURL.protocol === "file:" && !fs.existsSync(targetURL)) {
+      if (targetURL.protocol === "file:" && !fs.existsSync(currentFileURL)) {
         vfile.message("Broken link", node);
       } else if (targetURL.pathname === currentFileURL.pathname) {
         const expected = node.url.includes("#")


### PR DESCRIPTION
At L24 of your original code, we use something like fs.existsSync to check a file's existance or not：

```js
const targetURL = new URL(node.url, currentFileURL);
if (targetURL.protocol === "file:" && !fs.existsSync(targetURL))
```

That's the BUG! Because 'currentFileURL' will be an absolute file pointing to a certain doc on the local disc, so the result should be something like:

![WrongFileCheck](https://user-images.githubusercontent.com/52018749/125875517-b95c8052-bd6c-43cb-a88c-7341a7d7e2bb.JPG)

However, this will **always** return you false.

Futher more, a clear example is:
![image](https://user-images.githubusercontent.com/52018749/125879548-c8b81ff9-068b-46d4-8df0-95ffbdee379c.png)

Just see what's output? If you put the file into this project to have a play with, you will find the 1st result is "true", while the next is "false".

**#  Quick solution:**

Just check 'currentFileURL' is enough.