### PR TITLE
feat: split rules to separate names

### DIFF
--- a/getLinksRecursively.js
+++ b/getLinksRecursively.js
@@ -1,0 +1,10 @@
+"use strict";
+
+module.exports = function* getLinksRecursively(node) {
+  if (node.url) {
+    yield node;
+  }
+  for (const child of node.children || []) {
+    yield* getLinksRecursively(child);
+  }
+};

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports.plugins = [
   require("remark-lint"),
   // Leave preset at the top so it can be overridden
   require("remark-preset-lint-recommended"),
+  require("./remark-lint-alphabetize-references.js"),
   [require("remark-lint-blockquote-indentation"), 2],
   [
     require("remark-lint-checkbox-character-style"),
@@ -79,6 +80,7 @@ module.exports.plugins = [
     ],
   ],
   require("remark-lint-rule-style"),
+  require("./remark-lint-self-links"),
   [require("remark-lint-strong-marker"), "*"],
   [require("remark-lint-table-cell-padding"), "padded"],
   require("remark-lint-table-pipes"),

--- a/package.json
+++ b/package.json
@@ -28,8 +28,11 @@
   "homepage": "https://github.com/nodejs/remark-preset-lint-node#readme",
   "files": [
     "index.js",
+    "getLinksRecursively.js",
+    "remark-lint-alphabetize-references.js",
     "remark-lint-nodejs-links.js",
-    "remark-lint-nodejs-yaml-comments.js"
+    "remark-lint-nodejs-yaml-comments.js",
+    "remark-lint-self-links.js"
   ],
   "dependencies": {
     "js-yaml": "^4.0.0",

--- a/remark-lint-alphabetize-references.js
+++ b/remark-lint-alphabetize-references.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const rule = require("unified-lint-rule");
+const getLinksRecursively = require("./getLinksRecursively.js");
+
+function validateLinks(tree, vfile) {
+  let previousDefinitionLabel;
+  for (const node of getLinksRecursively(tree)) {
+    if (node.type === "definition") {
+      if (previousDefinitionLabel && previousDefinitionLabel > node.label) {
+        vfile.message(
+          `Unordered reference ("${node.label}" should be before "${previousDefinitionLabel}")`,
+          node
+        );
+      }
+      previousDefinitionLabel = node.label;
+    }
+  }
+}
+
+module.exports = rule("remark-lint-alphabetize-references", validateLinks);

--- a/remark-lint-self-links.js
+++ b/remark-lint-self-links.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const fs = require("fs");
 const path = require("path");
 const { pathToFileURL } = require("url");
 
@@ -13,11 +12,17 @@ function validateLinks(tree, vfile) {
   for (const node of getLinksRecursively(tree)) {
     if (node.url[0] !== "#") {
       const targetURL = new URL(node.url, currentFileURL);
-      if (targetURL.protocol === "file:" && !fs.existsSync(targetURL)) {
-        vfile.message("Broken link", node);
+      if (targetURL.pathname === currentFileURL.pathname) {
+        const expected = node.url.includes("#")
+          ? node.url.slice(node.url.indexOf("#"))
+          : "#";
+        vfile.message(
+          `Self-reference must start with hash (expected "${expected}", got "${node.url}")`,
+          node
+        );
       }
     }
   }
 }
 
-module.exports = rule("remark-lint:nodejs-links", validateLinks);
+module.exports = rule("remark-lint-self-links", validateLinks);


### PR DESCRIPTION
Trying out splitting up the link rules so they can be more granularly opted-in for non-core projects