### PR TITLE
chore: remove unneeded --use gfm from npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "lint": "eslint . && prettier . -c",
     "lockfile-lint": "lockfile-lint --allowed-hosts npm --allowed-schemes https: --empty-hostname false --type npm --path package-lock.json",
     "remark": "npm run remark-local && npm run remark-expected-failure && npm run remark-changes && npm run remark-node-core",
-    "remark-node-core": "remark \"tmp/*.md\" \"tmp/doc/**/*.md\" \"tmp/lib/**/*.md\" \"tmp/benchmark/**/*.md\" \"tmp/src/**/*.md\" \"tmp/test/README.md\" \"tmp/test/[a-eg-z]*/**/*.md\" \"tmp/tools/doc/*.md\" \"tmp/tools/icu/**/*.md\" --use ./index.js --use gfm -fq",
-    "remark-local": "remark *.md --use ./index.js --use gfm -fq",
-    "remark-expected-failure": "! remark test/fail.md --use ./index.js --use gfm -fq || (echo \"Error: failed to detect lint problems\" && exit 1)",
+    "remark-node-core": "remark \"tmp/*.md\" \"tmp/doc/**/*.md\" \"tmp/lib/**/*.md\" \"tmp/benchmark/**/*.md\" \"tmp/src/**/*.md\" \"tmp/test/README.md\" \"tmp/test/[a-eg-z]*/**/*.md\" \"tmp/tools/doc/*.md\" \"tmp/tools/icu/**/*.md\" --use ./index.js -fq",
+    "remark-local": "remark *.md --use ./index.js -fq",
+    "remark-expected-failure": "! remark test/fail.md --use ./index.js -fq || (echo \"Error: failed to detect lint problems\" && exit 1)",
     "remark-changes": "remark test/input.md --use ./index.js | diff test/output.md -",
     "test": "npm run lint && npm run lockfile-lint && npm run remark"
   },


### PR DESCRIPTION
We now package remark-gfm as part of this plugin so there is no need to
include it with a CLI flag.