### PR TITLE
fix: disable no-auto-link-without-protocol

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,8 @@ import remarkLintTableCellPadding from "remark-lint-table-cell-padding";
 import remarkLintTablePipes from "remark-lint-table-pipes";
 import remarkLintUnorderedListMarkerStyle from "remark-lint-unordered-list-marker-style";
 
-// Add in rules alphabetically
+// Add in rules alphabetically after Gfm and PresetLintRecommended.
 const plugins = [
-  // Leave GFM and preset at the top so they can be overridden
   remarkGfm,
   remarkPresetLintRecommended,
   [remarkLintBlockquoteIndentation, 2],
@@ -73,6 +72,7 @@ const plugins = [
   [remarkLintHeadingStyle, "atx"],
   [remarkLintListItemIndent, "space"],
   remarkLintMaximumLineLength,
+  ["remark-lint-no-auto-link-without-protocol", false],
   remarkLintNoConsecutiveBlankLines,
   remarkLintNoFileNameArticles,
   remarkLintNoFileNameConsecutiveDashes,

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
     "fix": "eslint . --fix && prettier . -w",
     "lint": "eslint . && prettier . -c",
     "lockfile-lint": "lockfile-lint --allowed-hosts npm --allowed-schemes https: --empty-hostname false --type npm --path package-lock.json",
-    "remark": "npm run remark-local && npm run remark-expected-failure && npm run remark-changes && npm run remark-node-core",
-    "remark-node-core": "remark \"tmp/*.md\" \"tmp/doc/**/*.md\" \"tmp/lib/**/*.md\" \"tmp/benchmark/**/*.md\" \"tmp/src/**/*.md\" \"tmp/test/README.md\" \"tmp/test/[a-eg-z]*/**/*.md\" \"tmp/tools/doc/*.md\" \"tmp/tools/icu/**/*.md\" --use ./index.js -fq",
+    "remark": "npm run remark-local && npm run remark-ok && npm run remark-fail && npm run remark-change && npm run remark-node-core",
+    "remark-change": "remark test/input.md --use ./index.js | diff test/output.md -",
     "remark-local": "remark *.md --use ./index.js -fq",
-    "remark-expected-failure": "! remark test/fail.md --use ./index.js -fq || (echo \"Error: failed to detect lint problems\" && exit 1)",
-    "remark-changes": "remark test/input.md --use ./index.js | diff test/output.md -",
+    "remark-node-core": "remark \"tmp/*.md\" \"tmp/doc/**/*.md\" \"tmp/lib/**/*.md\" \"tmp/benchmark/**/*.md\" \"tmp/src/**/*.md\" \"tmp/test/README.md\" \"tmp/test/[a-eg-z]*/**/*.md\" \"tmp/tools/doc/*.md\" \"tmp/tools/icu/**/*.md\" --use ./index.js -fq",
+    "remark-fail": "! remark test/fail.md --use ./index.js -fq || (echo \"Error: failed to detect lint problems\" && exit 1)",
+    "remark-ok": "remark test/ok.md --use ./index.js -fq",
     "test": "npm run lint && npm run lockfile-lint && npm run remark"
   },
   "repository": {

--- a/test/ok.md
+++ b/test/ok.md
@@ -1,0 +1,1 @@
+<fhqwhgads@example.com>


### PR DESCRIPTION
The rules conflicts with the output of remark-gfm, so we end up with a
lot of lint errors when using the preset for formatting markdown. It is
likely to be deprecated.

Ref: https://github.com/remarkjs/remark/discussions/863#discussioncomment-1383476