### PR TITLE
test: skip `mustCall` checks if there's already an error

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,7 @@ function mustCall(message = "The Promise never fulfilled") {
   };
 }
 process.on("exit", () => {
+  if (process.exitCode !== 0) return;
   for (const { error } of expectedCalls) {
     if (error) {
       throw error;


### PR DESCRIPTION
This avoids double reporting of the same error.

```js
[Error: ENOENT: no such file or directory, open '…/test/fixtures/fail-nodejs-yaml-comments.md'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '…/test/fixtures/fail-nodejs-yaml-comments.md'
}
file://…/test/test.js:28
      throw error;
      ^

Error: The Promise never fulfilled
    at mustCall (file://…/test/test.js:19:33)
    at file://…/test/test.js:69:11
```

The `The Promise never fulfilled` is not useful, as the error is already reported just above.