### PR TITLE
chore: update remark-lint-prohibited-strings to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2581,9 +2581,9 @@
       }
     },
     "remark-lint-prohibited-strings": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/remark-lint-prohibited-strings/-/remark-lint-prohibited-strings-3.0.0.tgz",
-      "integrity": "sha512-Aw21KVeoOiDte6dNfeTfTgjKV19yWXpPjLxfJ3ShC22/r97gkGdOo4dnuwyEEAfKhr3uimtSf3rRQyGSudY5tQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-prohibited-strings/-/remark-lint-prohibited-strings-3.1.0.tgz",
+      "integrity": "sha512-zwfDDdYl7ye0gEHcwhdkv1ZGXj1ibw4gnLLZkkvySnDdTz2tshY3fOJLY5NikbVseaIRVGOr5qa+8J9WNQT/fA==",
       "requires": {
         "escape-string-regexp": "^5.0.0",
         "unified-lint-rule": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "remark-lint-no-table-indentation": "^4.0.0",
     "remark-lint-no-tabs": "^3.0.0",
     "remark-lint-no-trailing-spaces": "^2.0.1",
-    "remark-lint-prohibited-strings": "^3.0.0",
+    "remark-lint-prohibited-strings": "^3.1.0",
     "remark-lint-rule-style": "^3.0.0",
     "remark-lint-strong-marker": "^3.0.0",
     "remark-lint-table-cell-padding": "^4.0.0",


### PR DESCRIPTION
Once this lands, all dependencies will be up to date. At that point, I'd like to publish a new minor because the remark-gfm update from several commits ago added the ability to use GFM footnotes, which will be helpful in some node core docs (like BUILDING.md).

Refs: https://github.com/remarkjs/remark-gfm/commit/890005e6253517c575dbd109d7149c16b7c26160
Refs: https://github.blog/changelog/2021-09-30-footnotes-now-supported-in-markdown-fields/

We could also publish the new release before that as anyone installing it will still get the most up-to-date remark-lint-prohibited-strings.