### PR TITLE
feat: allow ts blocks for Typescript

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ const plugins = [
         "powershell",
         "r",
         "text",
+        "ts",
       ],
     },
   ],


### PR DESCRIPTION
As part of https://github.com/nodejs/nodejs.dev/pull/2092 I needed to change some blocks to `ts` so ESLint can properly parse them, but that currently then fails this rule. We already have some other JS-like languages with `coffee` allowed.