### PR TITLE
ci: replace Node 12 for 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [12, 14, 16]
+        node:
+          - 14
+          - 16
+          - 18
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
12 is EOL and packages are dropping support now