### PR TITLE
chore: update test matrix to drop 14 and add 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 14
           - 16
           - 18
+          - 20
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Node.js 14