### PR TITLE
chore: drop support for Node.js earlier than 18.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 16
           - 18
           - 20
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/nodejs/remark-preset-lint-node/issues"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=18.0.0"
   },
   "homepage": "https://github.com/nodejs/remark-preset-lint-node#readme",
   "files": [


### PR DESCRIPTION
BREAKING CHANGE: requires Node.js 18.x or newer