### PR TITLE
chore: remove rule already included by recommended rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,6 @@ import remarkLintFileExtension from "remark-lint-file-extension";
 import remarkLintFinalDefinition from "remark-lint-final-definition";
 import remarkLintFirstHeadingLevel from "remark-lint-first-heading-level";
 import remarkLintHeadingStyle from "remark-lint-heading-style";
-import remarkLintListItemIndent from "remark-lint-list-item-indent";
 import remarkLintMaximumLineLength from "remark-lint-maximum-line-length";
 import remarkLintNoConsecutiveBlankLines from "remark-lint-no-consecutive-blank-lines";
 import remarkLintNoFileNameArticles from "remark-lint-no-file-name-articles";
@@ -71,7 +70,6 @@ const plugins = [
   remarkLintFinalDefinition,
   [remarkLintFirstHeadingLevel, 1],
   [remarkLintHeadingStyle, "atx"],
-  [remarkLintListItemIndent, "one"],
   [remarkLintMaximumLineLength, 120],
   remarkLintNoConsecutiveBlankLines,
   remarkLintNoFileNameArticles,
@@ -115,7 +113,6 @@ const plugins = [
 
 const settings = {
   emphasis: "_",
-  listItemIndent: "one",
   tightDefinitions: true,
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "remark-lint-final-definition": "^4.0.1",
         "remark-lint-first-heading-level": "^4.0.0",
         "remark-lint-heading-style": "^4.0.0",
-        "remark-lint-list-item-indent": "^4.0.0",
         "remark-lint-maximum-line-length": "^4.0.1",
         "remark-lint-no-consecutive-blank-lines": "^5.0.0",
         "remark-lint-no-file-name-articles": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "remark-lint-final-definition": "^4.0.1",
     "remark-lint-first-heading-level": "^4.0.0",
     "remark-lint-heading-style": "^4.0.0",
-    "remark-lint-list-item-indent": "^4.0.0",
     "remark-lint-maximum-line-length": "^4.0.1",
     "remark-lint-no-consecutive-blank-lines": "^5.0.0",
     "remark-lint-no-file-name-articles": "^3.0.0",


### PR DESCRIPTION
In the most recent version of the recommended rules, the configuration for remark-lint-list-item-indent was changed to what we use, so we no longer need to include the rule explicitly in our configuration.

Refs: https://github.com/remarkjs/remark-lint/commit/8df41b3c93be7c16082421c54830ab63b6fa0498