### PR TITLE
chore: Use Dependabot groups to bundle PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,18 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     versioning-strategy: widen
+    groups:
+      dev:
+        dependency-type: development
+        patterns:
+          - "*"
+      prod:
+        dependency-type: production
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Potentially this could just be one big blob of updates of prod+dev, but I thought splitting it might make sense. This way, the next time there is a ton of remark-lint bumps, we'll only get one PR.
I flipped the cadence for NPM PRs to weekly, since I don't know if there is a need for daily PRs, even with the bundled updates.