### PR TITLE
chore: pin Node.js test to 22.4 to avoid npm failures

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -20,7 +20,7 @@ jobs:
         node:
           - 18
           - 20
-          - 22
+          - 22.4
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
There's a bug in Node.js 22.5.0 that causes the npm installation step to fail. Pin testing to 22.4 until a fix comes out.