### PR TITLE
Revert "chore: pin Node.js test to 22.4 to avoid npm failures"

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -20,7 +20,7 @@ jobs:
         node:
           - 18
           - 20
-          - 22.4
+          - 22
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Reverts nodejs/remark-preset-lint-node#575

DNM, just opening as a reminder for when 22.5.x comes out