### PR TITLE
add 'wat' to allowed languages

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ const plugins = [
         "r",
         "text",
         "ts",
+        "wat",
       ],
     },
   ],


### PR DESCRIPTION
Useful for WebAssembly examples in the Node.js docs.