### PR TITLE
feat: add llm_description as a allowed key

### DIFF
--- a/remark-lint-nodejs-yaml-comments.js
+++ b/remark-lint-nodejs-yaml-comments.js
@@ -10,7 +10,7 @@ const allowedKeys = [
   "deprecated",
   "removed",
   "changes",
-  "llmDescription",
+  "llm_description",
 ];
 const changesExpectedKeys = ["version", "pr-url", "description"];
 const VERSION_PLACEHOLDER = "REPLACEME";

--- a/remark-lint-nodejs-yaml-comments.js
+++ b/remark-lint-nodejs-yaml-comments.js
@@ -10,6 +10,7 @@ const allowedKeys = [
   "deprecated",
   "removed",
   "changes",
+  "llmDescription",
 ];
 const changesExpectedKeys = ["version", "pr-url", "description"];
 const VERSION_PLACEHOLDER = "REPLACEME";


### PR DESCRIPTION
Adds `llm_description`, introduced in https://github.com/nodejs/doc-kit/pull/254, as a valid key, as required in https://github.com/nodejs/node/pull/59264.