### PR TITLE
ci: Update test matrix to Node.js 22, 24, 26

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - 18
-          - 20
           - 22
+          - 24
+          - 26
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Noticed https://github.com/nodejs/remark-preset-lint-node/pull/697 was failing because of some old Node.js versions in the CI matrix (plus some other things)